### PR TITLE
Add initial-build-settings.json

### DIFF
--- a/.cloudcannon/initial-build-settings.json
+++ b/.cloudcannon/initial-build-settings.json
@@ -1,0 +1,1 @@
+{"ssg":"sveltekit","build_configuration":{}}


### PR DESCRIPTION
Add .cloudcannon/initial-build-settings.json file. This specifies all the details CloudCannon needs to build the site, so that templates can be loaded directly into CloudCannon and built without asking the using for configuration. In most cases, the default config for the SSG is correct, so this file may only need to specify the SSG it uses.